### PR TITLE
Update SpencePence to rebase instead of requiring the birthday boy to claim inflation

### DIFF
--- a/contracts/SpencePence.sol
+++ b/contracts/SpencePence.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 
+import "hardhat/console.sol";
+
 contract SpencePence is Context, IERC20, IERC20Metadata {
     address public birthdayBoy;
 
@@ -128,15 +130,15 @@ contract SpencePence is Context, IERC20, IERC20Metadata {
 
     function _reduceBirthdayBoyBalance(uint256 amount) private {
         uint256 remainingAmount = amount;
-
         uint256 accruedSupply = _getBirthdayBoyAccruedSupply();
+
         if (remainingAmount > 0 && accruedSupply > 0) {
             if (remainingAmount >= accruedSupply) {
-                remainingAmount -= accruedSupply;
                 _totalSupplySpentByBirthdayBoy += accruedSupply;
+                remainingAmount -= accruedSupply;
             } else {
+                _totalSupplySpentByBirthdayBoy += remainingAmount;
                 remainingAmount = 0;
-                _totalSupplySpentByBirthdayBoy += (accruedSupply - remainingAmount);
             }
         }
 

--- a/contracts/SpencePence.sol
+++ b/contracts/SpencePence.sol
@@ -5,9 +5,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 
-// TODO remove
-import "hardhat/console.sol";
-
 contract SpencePence is Context, IERC20, IERC20Metadata {
     address public birthdayBoy;
 

--- a/contracts/SpencePence.sol
+++ b/contracts/SpencePence.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 
+// TODO remove
 import "hardhat/console.sol";
 
 contract SpencePence is Context, IERC20, IERC20Metadata {

--- a/contracts/SpencePence.sol
+++ b/contracts/SpencePence.sol
@@ -141,7 +141,7 @@ contract SpencePence is Context, IERC20, IERC20Metadata {
         }
 
         if (remainingAmount > 0) {
-            require(_balances[birthdayBoy] >= remainingAmount, "SpencePence: transfer amount exceeds balance");
+            assert(_balances[birthdayBoy] >= remainingAmount);
             _balances[birthdayBoy] -= remainingAmount;
         }
     }

--- a/contracts/SpencePence.sol
+++ b/contracts/SpencePence.sol
@@ -1,41 +1,160 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 
-contract SpencePence is ERC20, Ownable {
+contract SpencePence is Context, IERC20, IERC20Metadata {
     address public birthdayBoy;
-    uint256 public lastInflationAt;
 
-    uint256 private constant SPENCERS_30TH_BIRTHDAY_UTC = 1622692800 seconds;
+    mapping(address => uint256) private _balances;
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupplySpentByBirthdayBoy = 0;
+
+    string private constant NAME = "SpencePence";
+    string private constant SYMBOL = "SPNC";
+    uint256 private constant SPENCERS_BIRTHDAY_UTC = 675921600 seconds;
     uint256 private constant SECONDS_PER_YEAR = 31557600 seconds;
-    uint8 private constant INITIAL_SUPPLY = 30;
 
-    constructor() ERC20("SpencePence", "SPNC") {
-        _mint(owner(), _decimalAdjusted(INITIAL_SUPPLY));
-        lastInflationAt = SPENCERS_30TH_BIRTHDAY_UTC;
+    constructor(address _birthdayBoy) {
+        require(_birthdayBoy != address(0), "Birthday boy cannot be the zero address");
+        birthdayBoy = _birthdayBoy;
     }
 
-    modifier onlyBirthdayBoy() {
-        require(birthdayBoy != address(0), "SpencePence: No birthday boy is set");
-        require(msg.sender == birthdayBoy, "SpencePence: Caller is not the birthday boy");
-        _;
+    function name() public pure override returns (string memory) {
+        return NAME;
     }
 
-    function setBirthdayBoy(address newBirthdayBoy) external onlyOwner {
-        require(newBirthdayBoy != address(0), "SpencePence: Invalid birthday boy address");
-        birthdayBoy = newBirthdayBoy;
+    function symbol() public pure override returns (string memory) {
+        return SYMBOL;
     }
 
-    function claimInflation() external onlyBirthdayBoy {
-        uint256 secondsSinceLastInflation = block.timestamp - lastInflationAt;
-        uint256 amountToMint = secondsSinceLastInflation / SECONDS_PER_YEAR;
-        _mint(birthdayBoy, _decimalAdjusted(amountToMint));
-        lastInflationAt = block.timestamp;
+    function decimals() public pure override returns (uint8) {
+        return 18;
     }
 
-    function _decimalAdjusted(uint256 amount) internal view returns (uint256) {
-        return amount * (10**decimals());
+    function totalSupply() public view override returns (uint256) {
+        return _getBirthdaySupply();
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        uint256 accountBalance = _balances[account];
+        if (_isBirthdayBoy(account)) {
+            return accountBalance + _getBirthdayBoyAccruedSupply();
+        } else {
+            return accountBalance;
+        }
+    }
+
+    function transfer(address recipient, uint256 amount) public override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public override returns (bool) {
+        _transfer(sender, recipient, amount);
+
+        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        require(currentAllowance >= amount, "SpencePence: transfer amount exceeds allowance");
+        unchecked { _approve(sender, _msgSender(), currentAllowance - amount); }
+
+        return true;
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender] + addedValue);
+        return true;
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        require(currentAllowance >= subtractedValue, "SpencePence: decreased allowance below zero");
+        unchecked { _approve(_msgSender(), spender, currentAllowance - subtractedValue); }
+
+        return true;
+    }
+
+    function _getBirthdayBoyAccruedSupply() private view returns (uint256) {
+        return _getBirthdaySupply() - _totalSupplySpentByBirthdayBoy;
+    }
+
+    function _getBirthdaySupply() private view returns (uint256) {
+        return ((_getSpencersAgeSeconds() * (10**decimals())) / SECONDS_PER_YEAR);
+    }
+
+    function _getSpencersAgeSeconds() private view returns (uint256) {
+        return block.timestamp - SPENCERS_BIRTHDAY_UTC;
+    }
+
+    function _isBirthdayBoy(address account) private view returns (bool) {
+        return birthdayBoy == account;
+    }
+
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) private {
+        require(sender != address(0), "SpencePence: transfer from the zero address");
+        require(recipient != address(0), "SpencePence: transfer to the zero address");
+
+        uint256 senderBalance = balanceOf(sender);
+        require(senderBalance >= amount, "SpencePence: transfer amount exceeds balance");
+        if (_isBirthdayBoy(sender)) {
+            _reduceBirthdayBoyBalance(amount);
+        } else {
+            _balances[sender] = senderBalance - amount;
+        }
+
+        _balances[recipient] += amount;
+
+        emit Transfer(sender, recipient, amount);
+    }
+
+    function _reduceBirthdayBoyBalance(uint256 amount) private {
+        uint256 remainingAmount = amount;
+
+        uint256 accruedSupply = _getBirthdayBoyAccruedSupply();
+        if (remainingAmount > 0 && accruedSupply > 0) {
+            if (remainingAmount >= accruedSupply) {
+                remainingAmount -= accruedSupply;
+                _totalSupplySpentByBirthdayBoy += accruedSupply;
+            } else {
+                remainingAmount = 0;
+                _totalSupplySpentByBirthdayBoy += (accruedSupply - remainingAmount);
+            }
+        }
+
+        if (remainingAmount > 0) {
+            require(_balances[birthdayBoy] >= remainingAmount, "SpencePence: transfer amount exceeds balance");
+            _balances[birthdayBoy] -= remainingAmount;
+        }
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal {
+        require(owner != address(0), "SpencePence: approve from the zero address");
+        require(spender != address(0), "SpencePence: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
     }
 }

--- a/data/abi/SpencePence.json
+++ b/data/abi/SpencePence.json
@@ -1,6 +1,12 @@
 [
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_birthdayBoy",
+        "type": "address"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "constructor"
   },
@@ -27,25 +33,6 @@
       }
     ],
     "name": "Approval",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
     "type": "event"
   },
   {
@@ -155,13 +142,6 @@
   },
   {
     "inputs": [],
-    "name": "claimInflation",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "decimals",
     "outputs": [
       {
@@ -170,7 +150,7 @@
         "type": "uint8"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -223,19 +203,6 @@
   },
   {
     "inputs": [],
-    "name": "lastInflationAt",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "name",
     "outputs": [
       {
@@ -244,40 +211,7 @@
         "type": "string"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newBirthdayBoy",
-        "type": "address"
-      }
-    ],
-    "name": "setBirthdayBoy",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -290,7 +224,7 @@
         "type": "string"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -356,19 +290,6 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/data/abi/SpencePence.json
+++ b/data/abi/SpencePence.json
@@ -41,6 +41,25 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "previousBirthdayBoy",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newBirthdayBoy",
+        "type": "address"
+      }
+    ],
+    "name": "BirthdayBoyTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "from",
         "type": "address"
       },
@@ -261,6 +280,19 @@
         "type": "bool"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newBirthdayBoy",
+        "type": "address"
+      }
+    ],
+    "name": "transferBirthday",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/test/SpencePence.ts
+++ b/test/SpencePence.ts
@@ -79,10 +79,17 @@ describe("Unit tests", function () {
       await expectBalance(notBirthdayBoy, amountGivenAway.add(amountGivenAwayAgain).sub(amountGivenBack));
     });
 
+    it("should not allow transfers larger than supply", async function () {
+      await expect(
+        spencePence.connect(birthdayBoy).transfer(notBirthdayBoy.address, await asPence(1000)),
+      ).to.be.revertedWith("SpencePence: transfer amount exceeds balance");
+      await expect(
+        spencePence.connect(notBirthdayBoy).transfer(birthdayBoy.address, await asPence(1000)),
+      ).to.be.revertedWith("SpencePence: transfer amount exceeds balance");
+    });
+
     /**
      * Tests todo
-     * - test allowance
-     * - test that no one can transfer more than their balance
      * - test that supply increases with spencer's age
      */
   });

--- a/test/SpencePence.ts
+++ b/test/SpencePence.ts
@@ -51,11 +51,11 @@ describe("Unit tests", function () {
       const latestBlockTimestamp = (await ethers.provider.getBlock(latestBlockNumber)).timestamp;
       const spencersAgeSeconds = latestBlockTimestamp - SPENCERS_BIRTHDAY_UTC;
 
-      const expectedInitialSupply = (await asPence(1)).mul(spencersAgeSeconds).div(SECONDS_PER_YEAR);
-      const actualInitialSupply = await spencePence.balanceOf(birthdayBoy.address);
+      const expectedSupply = (await asPence(1)).mul(spencersAgeSeconds).div(SECONDS_PER_YEAR);
+      const actualSupply = await spencePence.balanceOf(birthdayBoy.address);
 
-      expect(actualInitialSupply).to.equal(expectedInitialSupply);
-      expect(actualInitialSupply).to.equal(await spencePence.totalSupply());
+      expect(actualSupply).to.equal(expectedSupply);
+      expect(actualSupply).to.equal(await spencePence.totalSupply());
     });
 
     it("should support transfers back and forth", async function () {
@@ -83,14 +83,23 @@ describe("Unit tests", function () {
       await expect(
         spencePence.connect(birthdayBoy).transfer(notBirthdayBoy.address, await asPence(1000)),
       ).to.be.revertedWith("SpencePence: transfer amount exceeds balance");
+
       await expect(
         spencePence.connect(notBirthdayBoy).transfer(birthdayBoy.address, await asPence(1000)),
       ).to.be.revertedWith("SpencePence: transfer amount exceeds balance");
     });
 
-    /**
-     * Tests todo
-     * - test that supply increases with spencer's age
-     */
+    it("should increase supply relative to spencer's age", async function () {
+      const spencersAgeYears = 1000;
+      const spencersAgeSeconds = SECONDS_PER_YEAR * spencersAgeYears;
+      const futureTimestamp = SPENCERS_BIRTHDAY_UTC + spencersAgeSeconds;
+      await timeTravelTo(futureTimestamp);
+
+      const expectedSupply = (await asPence(1)).mul(spencersAgeSeconds).div(SECONDS_PER_YEAR);
+      const actualSupply = await spencePence.balanceOf(birthdayBoy.address);
+
+      expect(actualSupply).to.equal(expectedSupply);
+      expect(actualSupply).to.equal(await spencePence.totalSupply());
+    });
   });
 });


### PR DESCRIPTION
Reuses large pieces from openzeppelin ERC20

Wasn't able to inherit because I needed direct access to `_balances` to reimplement `_transfer` correctly